### PR TITLE
Fix arctan loop termination

### DIFF
--- a/arctan/main.py
+++ b/arctan/main.py
@@ -15,7 +15,7 @@ class ArctanCalculator:
         term = Decimal(1) / Decimal(x)  # First term of the series
         n = 0
 
-        while term > Decimal(10) ** (-self.precision):
+        while abs(term) > Decimal(10) ** (-self.precision):
             arctan_value += term / (2 * n + 1)
             n += 1
             term *= -Decimal(1) / (x * x)


### PR DESCRIPTION
## Summary
- ensure the arctan series loops while the absolute value of each term is above the precision limit
- keep file with newline at EOF

## Testing
- `python arctan/main.py <<'EOF'
2
2
EOF`
- `python -m trace --count arctan/main.py <<'EOF'
2
2
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684e88ae26f08332ac244ce230408b4e