### PR TITLE
🧪 test: add binomial coefficient test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+__pycache__/
+*.pyc

--- a/Tests/test_DiscreteMath.py
+++ b/Tests/test_DiscreteMath.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import pytest
+
+# Adjusting sys.path to allow imports from Math/Discrete_Math/Combinatorics
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../Math/Discrete_Math/Combinatorics')))
+# Adjusting sys.path to allow imports like 'from Numerical_Methods...'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../Math')))
+
+from binomial_theorem import binomial_coefficient
+
+def test_binomial_coefficient_normal():
+    assert binomial_coefficient(5, 2) == 10
+    assert binomial_coefficient(10, 3) == 120
+    assert binomial_coefficient(6, 3) == 20
+
+def test_binomial_coefficient_edge_cases():
+    assert binomial_coefficient(5, 0) == 1
+    assert binomial_coefficient(5, 5) == 1
+    assert binomial_coefficient(0, 0) == 1
+
+def test_binomial_coefficient_error_handling():
+    with pytest.raises(ValueError, match="Invalid values for n and r"):
+        binomial_coefficient(5, 6)
+    with pytest.raises(ValueError, match="Invalid values for n and r"):
+        binomial_coefficient(5, -1)


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `binomial_coefficient` function located in `Math/Discrete_Math/Combinatorics/binomial_theorem.py`. Also added `.gitignore` rules for python cache directories and files to avoid accidental commits.

📊 **Coverage:**
The tests now cover:
- Standard paths (e.g., C(5,2)=10)
- Edge cases (e.g., r=0, n=r, n=0, r=0)
- Error handling (e.g., r < 0, r > n returning ValueError)

✨ **Result:**
The test file `Tests/test_DiscreteMath.py` is successfully set up and configured correctly to ensure these tests can be run seamlessly using pytest, acting as a reliable safety net for any future refactoring.

---
*PR created automatically by Jules for task [14694399600375822834](https://jules.google.com/task/14694399600375822834) started by @Arjundevjha*