### PR TITLE
🧪 Add tests for format_polynomial

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -1,0 +1,33 @@
+import pytest
+from Math.Calculus.Differentiation.quotient_rule import format_polynomial
+
+
+def test_format_polynomial_basic():
+    coeffs = [2, 3]
+    powers = [2, 1]
+    result = format_polynomial(coeffs, powers)
+    terms = [t.strip() for t in result.split('+')]
+    assert "2x^2" in terms
+    assert "3x^1" in terms
+
+def test_format_polynomial_floats():
+    coeffs = [2.5, 3.1]
+    powers = [2.0, 0.0]
+    result = format_polynomial(coeffs, powers)
+    terms = [t.strip() for t in result.split('+')]
+    assert "2.5x^2" in terms
+    assert "3.1x^0" in terms
+
+def test_format_polynomial_negative_powers_and_coeffs():
+    coeffs = [-1, 0]
+    powers = [-2, 3]
+    result = format_polynomial(coeffs, powers)
+    terms = [t.strip() for t in result.split('+')]
+    assert "-1x^-2" in terms
+    assert "0x^3" in terms
+
+def test_format_polynomial_empty():
+    coeffs = []
+    powers = []
+    result = format_polynomial(coeffs, powers)
+    assert result.strip() == ""


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `format_polynomial` function in `Math/Calculus/Differentiation/quotient_rule.py` lacked test coverage. 

📊 **Coverage:** What scenarios are now tested
- Basic positive integer coefficients and powers.
- Float coefficients and powers.
- Negative coefficients and powers.
- Empty lists for coefficients and powers.

✨ **Result:** The improvement in test coverage
The test coverage has been improved with a new robust test file for Calculus modules (`Tests/test_Calculus.py`) testing different branches and inputs of the string formatting logic. The tests avoid strict brittle matching by extracting polynomial terms directly from the resulting string.

---
*PR created automatically by Jules for task [4140693788988396447](https://jules.google.com/task/4140693788988396447) started by @Arjundevjha*