### PR TITLE
🧪 Add tests for format_polynomial

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if root_dir not in sys.path:
+    sys.path.insert(0, root_dir)
+
+from Math.Calculus.Differentiation.product_rule import format_polynomial
+
+class TestCalculusDifferentiation(unittest.TestCase):
+    def test_format_polynomial_basic(self):
+        self.assertEqual(format_polynomial([2, 3], [1, 2]), "2x^1 + 3x^2")
+
+    def test_format_polynomial_empty(self):
+        self.assertEqual(format_polynomial([], []), "")
+
+    def test_format_polynomial_single_term(self):
+        self.assertEqual(format_polynomial([5], [0]), "5x^0")
+
+    def test_format_polynomial_floats(self):
+        self.assertEqual(format_polynomial([2.5, 3.1], [1.0, 2.0]), "2.5x^1 + 3.1x^2")
+
+    def test_format_polynomial_zero_coeff(self):
+        self.assertEqual(format_polynomial([0, 1], [2, 1]), "0x^2 + 1x^1")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for `format_polynomial` in `Math/Calculus/Differentiation/product_rule.py`.
📊 **Coverage:** Scenarios covered include basic functionality, empty arrays, single terms, floating point coefficients and powers, and zero coefficients.
✨ **Result:** Enhanced test coverage and reliability for this polynomial string formatting helper, making it safer for potential future refactorings.

---
*PR created automatically by Jules for task [16722071572986752384](https://jules.google.com/task/16722071572986752384) started by @Arjundevjha*