### PR TITLE
🧪 Add tests for chain_rule_derivative

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -204,6 +204,28 @@ def test_chain_rule_derivative_negative_exponent():
     with pytest.raises(ValueError, match="Exponent must be non-negative."):
         chain_rule_derivative([1, 2], [2, 0], -1)
 
+def test_chain_rule_derivative_empty():
+    result = chain_rule_derivative([], [], 2)
+    assert result == "2()^1 * ()"
+
+def test_chain_rule_derivative_float_coeffs():
+    result = chain_rule_derivative([2.5], [2.0], 4)
+    assert "4(" in result
+    assert "2.5x^2" in result
+    assert ")^3" in result
+    assert "* (5.0x^1)" in result
+
+def test_chain_rule_derivative_negative_powers():
+    result = chain_rule_derivative([3], [-2], 2)
+    assert result == "2(3x^-2)^1 * (-6x^-3)"
+
+def test_chain_rule_derivative_exponent_one():
+    result = chain_rule_derivative([4, 1], [3, 0], 1)
+    assert "1(" in result
+    assert "4x^3 + 1x^0" in result
+    assert ")^0" in result
+    assert "* (12x^2)" in result
+
 def test_integrate_cos_basic():
     # Integral of cos(x) from 0 to pi/2 should be sin(pi/2) - sin(0) = 1 - 0 = 1
     result = integrate_cos(0, math.pi / 2)


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `chain_rule_derivative` in `chain_rule.py`.
📊 **Coverage:** Tests now cover edge cases like empty lists, float coefficients, negative powers, and an exponent of one.
✨ **Result:** Test coverage for `Math.Calculus.Differentiation.chain_rule` has been improved, making the function more reliable and resistant to regressions.

---
*PR created automatically by Jules for task [16330119538769756031](https://jules.google.com/task/16330119538769756031) started by @Arjundevjha*