### PR TITLE
🧪 Add tests for integrate_cos in TrigIntegration.py

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -7,6 +7,10 @@ root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if root_dir not in sys.path:
     sys.path.insert(0, root_dir)
 
+math_dir = os.path.join(root_dir, 'Math')
+if math_dir not in sys.path:
+    sys.path.insert(0, math_dir)
+
 from Math.Calculus.Differentiation.second_derivatives import second_derivative
 from Math.Calculus.Differentiation.product_rule import compute_polynomial_derivative_str, product_rule_derivative, format_polynomial as format_polynomial_product_rule
 from Math.Calculus.Integration.NumIntegration import integrate_polynomial, format_polynomial_integration
@@ -541,6 +545,16 @@ class TestTrigIntegration:
         """Test integral of cos(x) from 0 to 0 = 0"""
         result = integrate_cos(0, 0)
         assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_full_period(self):
+        """Test integral of cos(x) from 0 to 2pi = 0"""
+        result = integrate_cos(0, 2 * math.pi)
+        assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_negative_bounds(self):
+        """Test integral of cos(x) from -pi/2 to pi/2 = 2"""
+        result = integrate_cos(-math.pi / 2, math.pi / 2)
+        assert math.isclose(result, 2.0, rel_tol=1e-5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests were lacking for the `integrate_cos` function in `TrigIntegration.py`. I've added robust tests to cover edge cases.

📊 **Coverage:** What scenarios are now tested
Tests now cover `integrate_cos`:
- Basic bound checks from 0 to pi/2 (value 1.0)
- Zero bound integration from 0 to 0 (value 0.0)
- Full period integration from 0 to 2pi (value 0.0)
- Negative bound integration from -pi/2 to pi/2 (value 2.0)

✨ **Result:** The improvement in test coverage
`integrate_cos` now has extensive coverage checking properties of trigonometric integrations, utilizing `math.isclose` to avoid floating-point inaccuracies.

---
*PR created automatically by Jules for task [12974423332380039967](https://jules.google.com/task/12974423332380039967) started by @Arjundevjha*