### PR TITLE
🧪 Add tests for format_polynomial in chain_rule.py

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -432,6 +432,24 @@ def test_format_polynomial_chain_rule_2_negative_powers():
 
 def test_format_polynomial_chain_rule_2_negative_coeffs():
     assert format_polynomial_chain_rule([-3, -4], [2, 1]) == "-3x^2 + -4x^1"
+
+def test_format_polynomial_chain_rule_floating_point_powers():
+    # Floating point powers should be cast to int as per the code: `int(power)`
+    assert format_polynomial_chain_rule([2, 3], [2.5, 1.9]) == "2x^2 + 3x^1"
+
+def test_format_polynomial_chain_rule_zero_coefficients():
+    # Test with 0 as coefficient
+    assert format_polynomial_chain_rule([0, 1], [2, 1]) == "0x^2 + 1x^1"
+
+def test_format_polynomial_chain_rule_zero_power():
+    # Test with 0 as power
+    assert format_polynomial_chain_rule([5, 2], [1, 0]) == "5x^1 + 2x^0"
+
+def test_format_polynomial_chain_rule_unequal_lengths():
+    # zip should truncate to the shorter list
+    assert format_polynomial_chain_rule([1, 2, 3], [1, 0]) == "1x^1 + 2x^0"
+    assert format_polynomial_chain_rule([1, 2], [2, 1, 0]) == "1x^2 + 2x^1"
+
 class TestComputePolynomialDerivative:
     def test_basic_polynomial(self):
         # f(x) = 3x^2 + 2x^1


### PR DESCRIPTION
🎯 **What:** Added comprehensive test cases to `Tests/test_Calculus.py` for the `format_polynomial` function in `Math/Calculus/Differentiation/chain_rule.py`.
📊 **Coverage:** The new tests cover scenarios like floating point powers, zero coefficients, zero powers, and lists of unequal lengths which verifies `zip()` truncation behavior.
✨ **Result:** Improved test coverage and assurance that formatting polynomials gracefully handles various types of inputs.

---
*PR created automatically by Jules for task [8780060989769622914](https://jules.google.com/task/8780060989769622914) started by @Arjundevjha*