### PR TITLE
🧪 Fix check_factor precision issue and improve testing

### DIFF
--- a/Math/Algebra/Polynomials/factor_theorem.py
+++ b/Math/Algebra/Polynomials/factor_theorem.py
@@ -1,5 +1,6 @@
 # Factor theorem: check if (x - a) is a factor of a polynomial
 from typing import List, Union
+import math
 
 
 def evaluate_polynomial(coefficients: List[Union[int, float]], powers: List[Union[int, float]], x: Union[int, float]) -> float:
@@ -34,4 +35,5 @@ def check_factor(coefficients: List[Union[int, float]], powers: List[Union[int, 
     # According to Factor Theorem: (x - a) is a factor if P(a) = 0
     result = evaluate_polynomial(coefficients, powers, x)
     
-    return result == 0
+    # Use math.isclose to account for floating-point precision issues
+    return math.isclose(result, 0.0, abs_tol=1e-9)

--- a/Tests/test_Algebra.py
+++ b/Tests/test_Algebra.py
@@ -140,6 +140,20 @@ def test_check_factor_float():
     assert check_factor(coefficients, powers, -0.5) is True
     assert check_factor(coefficients, powers, 1.0) is True
     assert check_factor(coefficients, powers, 0.5) is False
+
+def test_check_factor_precision():
+    # P(x) = x^2 - 2, check if x = sqrt(2) is a factor
+    # This evaluates to ~4.44e-16 instead of exactly 0 due to float precision
+    import math
+    assert check_factor([1, -2], [2, 0], math.sqrt(2)) is True
+
+def test_check_factor_empty():
+    # P(x) = 0
+    assert check_factor([], [], 5) is True
+
+def test_check_factor_zero():
+    # P(x) = 0x^2
+    assert check_factor([0], [2], 10) is True
 def test_evaluate_polynomial_poly_basic():
     # P(x) = 2x^2 + 3x + 1
     # P(2) = 2(2^2) + 3(2) + 1 = 8 + 6 + 1 = 15


### PR DESCRIPTION
🎯 **What:** The `check_factor` function in `Math/Algebra/Polynomials/factor_theorem.py` relied on an exact equality check (`result == 0`) for floating-point calculations, which often failed due to precision issues (e.g. `P(math.sqrt(2))` for `x^2 - 2`). Added robust testing for these edge cases.
📊 **Coverage:** Covered precision issues with floats (`math.sqrt(2)`), an empty coefficient check (`test_check_factor_empty`), and a zero coefficient check (`test_check_factor_zero`).
✨ **Result:** Improved test coverage significantly and made the core implementation of `check_factor` resilient to floating point inaccuracies by switching to `math.isclose`.

---
*PR created automatically by Jules for task [6134267340735945779](https://jules.google.com/task/6134267340735945779) started by @Arjundevjha*