### PR TITLE
🧪 Add tests for integrate_cos in TrigIntegration.py

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -7,6 +7,10 @@ root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if root_dir not in sys.path:
     sys.path.insert(0, root_dir)
 
+math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'Math'))
+if math_dir not in sys.path:
+    sys.path.insert(0, math_dir)
+
 from Math.Calculus.Differentiation.second_derivatives import second_derivative
 from Math.Calculus.Differentiation.product_rule import compute_polynomial_derivative_str, product_rule_derivative, format_polynomial as format_polynomial_product_rule
 from Math.Calculus.Integration.NumIntegration import integrate_polynomial, format_polynomial_integration
@@ -541,6 +545,27 @@ class TestTrigIntegration:
         """Test integral of cos(x) from 0 to 0 = 0"""
         result = integrate_cos(0, 0)
         assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_full_period(self):
+        """Test integral of cos(x) from 0 to 2pi = 0"""
+        result = integrate_cos(0, 2 * math.pi)
+        assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_negative_bounds(self):
+        """Test integral of cos(x) from -pi to 0 = 0"""
+        result = integrate_cos(-math.pi, 0)
+        assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_reversed_bounds(self):
+        """Test integral of cos(x) from pi/2 to 0 = -1"""
+        result = integrate_cos(math.pi / 2, 0)
+        assert math.isclose(result, -1.0, rel_tol=1e-5)
+
+    def test_integrate_cos_fractional_bounds(self):
+        """Test integral of cos(x) from pi/6 to pi/3 = (sqrt(3)/2 - 1/2)"""
+        result = integrate_cos(math.pi / 6, math.pi / 3)
+        expected = math.sin(math.pi / 3) - math.sin(math.pi / 6)
+        assert math.isclose(result, expected, rel_tol=1e-5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests for the `integrate_cos` function in `TrigIntegration.py`. Addressed `ModuleNotFoundError` by adding `Math` directory to `sys.path`.
📊 **Coverage:** Added coverage for:
- Full period integration (`0` to `2pi`)
- Negative integration bounds (`-pi` to `0`)
- Reversed integration bounds (`pi/2` to `0`)
- Fractional/Non-zero integer bounds (`pi/6` to `pi/3`)
✨ **Result:** Increased code coverage and confidence in `integrate_cos` behavior across different inputs without introducing regressions.

---
*PR created automatically by Jules for task [4409705121295988336](https://jules.google.com/task/4409705121295988336) started by @Arjundevjha*