### PR TITLE
🧪 [Testing Improvement] Add tests for integrate_cos

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -7,6 +7,11 @@ root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if root_dir not in sys.path:
     sys.path.insert(0, root_dir)
 
+math_dir = os.path.join(root_dir, 'Math')
+if math_dir not in sys.path:
+    sys.path.insert(0, math_dir)
+
+
 from Math.Calculus.Differentiation.second_derivatives import second_derivative
 from Math.Calculus.Differentiation.product_rule import compute_polynomial_derivative_str, product_rule_derivative, format_polynomial as format_polynomial_product_rule
 from Math.Calculus.Integration.NumIntegration import integrate_polynomial, format_polynomial_integration
@@ -541,6 +546,21 @@ class TestTrigIntegration:
         """Test integral of cos(x) from 0 to 0 = 0"""
         result = integrate_cos(0, 0)
         assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_full_period(self):
+        """Test integral of cos(x) from 0 to 2pi = 0"""
+        result = integrate_cos(0, 2 * math.pi)
+        assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_negative_bounds(self):
+        """Test integral of cos(x) from -pi/2 to 0 = 1"""
+        result = integrate_cos(-math.pi / 2, 0)
+        assert math.isclose(result, 1.0, rel_tol=1e-5)
+
+    def test_integrate_cos_same_bounds(self):
+        """Test integral of cos(x) from a to a = 0"""
+        result = integrate_cos(math.pi, math.pi)
+        assert math.isclose(result, 0.0, abs_tol=1e-5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing test cases for `integrate_cos` in `Math/Calculus/Integration/TrigIntegration.py`.

📊 **Coverage:** What scenarios are now tested
- Evaluation over positive bounds.
- Evaluation over a full period (`0` to `2pi`).
- Evaluation using negative bounds.
- Evaluation using the same bound for the lower and upper bounds.

✨ **Result:** The improvement in test coverage
- `integrate_cos` now has fully covered unit tests catching normal usages and edge cases (same bounds, negative values, full period), allowing confident refactoring.

---
*PR created automatically by Jules for task [15101831992536969132](https://jules.google.com/task/15101831992536969132) started by @Arjundevjha*