### PR TITLE
🧪 Add tests for integrate_polynomial in NumIntegration.py

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -103,6 +103,23 @@ def test_integrate_polynomial_zero_coefficients():
 
     assert integrate_polynomial(coeffs, powers) == (expected_coeffs, expected_powers)
 
+def test_integrate_polynomial_empty():
+    # ∫(0)dx = C
+    coeffs = []
+    powers = []
+    expected_coeffs = []
+    expected_powers = []
+
+    assert integrate_polynomial(coeffs, powers) == (expected_coeffs, expected_powers)
+
+def test_integrate_polynomial_power_minus_one():
+    # ∫(x^-1)dx raises ZeroDivisionError in this naive implementation
+    coeffs = [1]
+    powers = [-1]
+
+    with pytest.raises(ZeroDivisionError):
+        integrate_polynomial(coeffs, powers)
+
 def test_format_polynomial_integration_basic():
     # x^3 + x^2 + x + C
     coeffs = [1.0, 1.0, 1.0]


### PR DESCRIPTION
🎯 **What:** Added tests for the `integrate_polynomial` function in `NumIntegration.py`.
📊 **Coverage:** Covered edge cases with empty input lists, and the known limitation of the current naive integration implementation which causes a `ZeroDivisionError` when a power of `-1` is provided. Existing tests already cover basic scenarios, negative powers (non -1), fractional powers, and zero coefficients.
✨ **Result:** Increased testing robustness and clearly documented the current expected behavior on edge cases and failure modes.

---
*PR created automatically by Jules for task [11345259730232332428](https://jules.google.com/task/11345259730232332428) started by @Arjundevjha*