### PR TITLE
🧪 Add tests for integrate_cos in TrigIntegration

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -6,6 +6,9 @@ import unittest
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if root_dir not in sys.path:
     sys.path.insert(0, root_dir)
+math_dir = os.path.join(root_dir, "Math")
+if math_dir not in sys.path:
+    sys.path.insert(0, math_dir)
 
 from Math.Calculus.Differentiation.second_derivatives import second_derivative
 from Math.Calculus.Differentiation.product_rule import compute_polynomial_derivative_str, product_rule_derivative, format_polynomial as format_polynomial_product_rule
@@ -540,6 +543,21 @@ class TestTrigIntegration:
     def test_integrate_cos_zero(self):
         """Test integral of cos(x) from 0 to 0 = 0"""
         result = integrate_cos(0, 0)
+        assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_full_period(self):
+        """Test integral of cos(x) from 0 to 2pi = 0"""
+        result = integrate_cos(0, 2 * math.pi)
+        assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+    def test_integrate_cos_negative_bounds(self):
+        """Test integral of cos(x) from -pi/2 to 0 = 1"""
+        result = integrate_cos(-math.pi / 2, 0)
+        assert math.isclose(result, 1.0, rel_tol=1e-5)
+
+    def test_integrate_cos_same_bounds(self):
+        """Test integral of cos(x) from a to a = 0"""
+        result = integrate_cos(math.pi, math.pi)
         assert math.isclose(result, 0.0, abs_tol=1e-9)
 
 if __name__ == '__main__':


### PR DESCRIPTION
🎯 **What:** Added tests for `integrate_cos` inside `Math/Calculus/Integration/TrigIntegration.py` which was lacking coverage compared to `integrate_sin`.

📊 **Coverage:** 
- Basic case (0 to pi/2)
- Full period integration (0 to 2pi)
- Negative bounds (-pi/2 to 0)
- Identical start and end bounds (pi to pi)

✨ **Result:** Improved test coverage for integration functionality, guaranteeing the mathematical robustness of the library without introducing regressions.

---
*PR created automatically by Jules for task [3518816617813130167](https://jules.google.com/task/3518816617813130167) started by @Arjundevjha*