### PR TITLE
🧪 Add tests for format_polynomial in chain_rule.py

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -432,6 +432,18 @@ def test_format_polynomial_chain_rule_2_negative_powers():
 
 def test_format_polynomial_chain_rule_2_negative_coeffs():
     assert format_polynomial_chain_rule([-3, -4], [2, 1]) == "-3x^2 + -4x^1"
+
+def test_format_polynomial_chain_rule_zero_coeff():
+    assert format_polynomial_chain_rule([0, 2], [2, 1]) == "0x^2 + 2x^1"
+
+def test_format_polynomial_chain_rule_zero_power():
+    assert format_polynomial_chain_rule([3], [0]) == "3x^0"
+
+def test_format_polynomial_chain_rule_mismatched_lengths():
+    # zip should truncate to the shortest list
+    assert format_polynomial_chain_rule([1, 2, 3], [2, 1]) == "1x^2 + 2x^1"
+    assert format_polynomial_chain_rule([1, 2], [2, 1, 0]) == "1x^2 + 2x^1"
+
 class TestComputePolynomialDerivative:
     def test_basic_polynomial(self):
         # f(x) = 3x^2 + 2x^1


### PR DESCRIPTION
🎯 **What:** Added tests for the `format_polynomial` function in `Math/Calculus/Differentiation/chain_rule.py`.
📊 **Coverage:** Covered edge cases such as zero coefficients, zero powers, and mismatched list lengths.
✨ **Result:** Improved test coverage and confidence for the `format_polynomial` function in the chain rule differentiation module.

---
*PR created automatically by Jules for task [3710612787174794266](https://jules.google.com/task/3710612787174794266) started by @Arjundevjha*