### PR TITLE
🧪 Add tests for format_polynomial in quotient_rule.py

### DIFF
--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -367,6 +367,21 @@ def test_format_polynomial_chain_rule_mixed():
     assert "4.5x^0" in terms
     assert len(terms) == 2
 class TestQuotientRule(unittest.TestCase):
+    def test_format_polynomial_quotient_rule_basic(self):
+        self.assertEqual(format_polynomial([3], [2]), "3x^2")
+
+    def test_format_polynomial_quotient_rule_multiple_terms(self):
+        self.assertEqual(format_polynomial([3, 2, 1], [2, 1, 0]), "3x^2 + 2x^1 + 1x^0")
+
+    def test_format_polynomial_quotient_rule_floats(self):
+        self.assertEqual(format_polynomial([1.5, 2.5], [2, 1]), "1.5x^2 + 2.5x^1")
+
+    def test_format_polynomial_quotient_rule_negative_powers(self):
+        self.assertEqual(format_polynomial([3], [-2]), "3x^-2")
+
+    def test_format_polynomial_quotient_rule_empty(self):
+        self.assertEqual(format_polynomial([], []), "")
+
     def test_compute_polynomial_derivative_str_basic(self):
         self.assertEqual(compute_polynomial_derivative_str([3], [2]), "6x^1")
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests have been added for the `format_polynomial` function inside `Math/Calculus/Differentiation/quotient_rule.py` as it was lacking coverage.

📊 **Coverage:** What scenarios are now tested
- Basic terms (`[3], [2]` -> `"3x^2"`)
- Multiple terms (`[3, 2, 1], [2, 1, 0]`)
- Floating point coefficients (`[1.5, 2.5], [2, 1]`)
- Negative powers (`[3], [-2]`)
- Empty list arguments (`[], []`)

✨ **Result:** The improvement in test coverage
The `format_polynomial` function within `quotient_rule.py` now has robust test coverage through unit testing, enhancing the stability of the differentiation formatting logic. Tests pass seamlessly alongside the entire suite.

---
*PR created automatically by Jules for task [10226569367938930560](https://jules.google.com/task/10226569367938930560) started by @Arjundevjha*