### PR TITLE
🧪 Add tests for format_polynomial in polynomial.py

### DIFF
--- a/Tests/test_Algebra.py
+++ b/Tests/test_Algebra.py
@@ -34,6 +34,29 @@ def test_format_polynomial_floats():
     assert "-2.5x" in terms
     assert "3.1" in terms
 
+def test_format_polynomial_single_term():
+    result = format_polynomial([5], [3])
+    terms = [t.strip() for t in result.split("+")]
+    assert "5x^3" in terms
+
+def test_format_polynomial_negative_powers():
+    result = format_polynomial([2, -3], [-1, -2])
+    terms = [t.strip() for t in result.split("+")]
+    assert "2x^-1" in terms
+    assert "-3x^-2" in terms
+
+def test_format_polynomial_all_zero_powers():
+    result = format_polynomial([1, 2], [0, 0])
+    terms = [t.strip() for t in result.split("+")]
+    assert "1" in terms
+    assert "2" in terms
+
+def test_format_polynomial_all_ones_powers():
+    result = format_polynomial([3, 4], [1, 1])
+    terms = [t.strip() for t in result.split("+")]
+    assert "3x" in terms
+    assert "4x" in terms
+
 def test_linear_eqn_positive_slope():
     # Points: (1, 2) and (3, 6)
     # m = (6 - 2) / (3 - 1) = 4 / 2 = 2.0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `format_polynomial` function in `Math/Algebra/Polynomials/polynomial.py` lacked robust test coverage for various edge cases like single terms, negative powers, zero powers, and single power scenarios.

📊 **Coverage:** What scenarios are now tested
- Single term polynomials
- Polynomials with negative powers
- Polynomials with zero powers (all terms have power 0)
- Polynomials with powers of one (all terms have power 1)

✨ **Result:** The improvement in test coverage
Test suite now fully exercises `format_polynomial`, ensuring its string formatting correctly handles various mathematical structures and boundaries.

---
*PR created automatically by Jules for task [5352382636648221375](https://jules.google.com/task/5352382636648221375) started by @Arjundevjha*