### PR TITLE
🧪 Add tests for compute_polynomial_derivative_str in quotient_rule.py

### DIFF
--- a/Math/Calculus/Integration/TrigIntegration.py
+++ b/Math/Calculus/Integration/TrigIntegration.py
@@ -1,6 +1,10 @@
 # Trigonometric integration formulas
+import os
 import sys
-sys.path.append('../..')
+# Add Math to path to fix imports inside Math
+math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+if math_dir not in sys.path:
+    sys.path.insert(0, math_dir)
 from Geometry.Trigonometry.Trig_Functions.sine import sine
 from Geometry.Trigonometry.Trig_Functions.cosine import cosine
 from typing import Union

--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -10,7 +10,7 @@ if root_dir not in sys.path:
 from Math.Calculus.Differentiation.second_derivatives import second_derivative
 from Math.Calculus.Differentiation.product_rule import compute_polynomial_derivative_str, product_rule_derivative, format_polynomial as format_polynomial_product_rule
 from Math.Calculus.Integration.NumIntegration import integrate_polynomial, format_polynomial_integration
-from Math.Calculus.Differentiation.quotient_rule import format_polynomial, quotient_rule_derivative
+from Math.Calculus.Differentiation.quotient_rule import format_polynomial, quotient_rule_derivative, compute_polynomial_derivative_str as compute_polynomial_derivative_str_quotient
 from Math.Calculus.Differentiation.chain_rule import chain_rule_derivative, format_polynomial as format_polynomial_chain_rule, compute_polynomial_derivative
 from Math.Calculus.Integration.TrigIntegration import integrate_cos, integrate_sin
 from Math.Calculus.Differentiation.simple_diffrentiation_function import differentiate_polynomial
@@ -368,25 +368,42 @@ def test_format_polynomial_chain_rule_mixed():
     assert len(terms) == 2
 class TestQuotientRule(unittest.TestCase):
     def test_compute_polynomial_derivative_str_basic(self):
-        self.assertEqual(compute_polynomial_derivative_str([3], [2]), "6x^1")
+        result = compute_polynomial_derivative_str_quotient([3], [2])
+        terms = [t.strip() for t in result.split("+")]
+        self.assertIn("6x^1", terms)
+        self.assertEqual(len(terms), 1)
 
     def test_compute_polynomial_derivative_str_multiple_terms(self):
-        self.assertEqual(compute_polynomial_derivative_str([3, 2, 1], [2, 1, 0]), "6x^1 + 2x^0")
+        result = compute_polynomial_derivative_str_quotient([3, 2, 1], [2, 1, 0])
+        terms = [t.strip() for t in result.split("+")]
+        self.assertIn("6x^1", terms)
+        self.assertIn("2x^0", terms)
+        self.assertEqual(len(terms), 2)
 
     def test_compute_polynomial_derivative_str_constant(self):
-        self.assertEqual(compute_polynomial_derivative_str([5], [0]), "0")
+        self.assertEqual(compute_polynomial_derivative_str_quotient([5], [0]), "0")
 
     def test_compute_polynomial_derivative_str_zero_coefficient(self):
-        self.assertEqual(compute_polynomial_derivative_str([0], [2]), "0x^1")
+        result = compute_polynomial_derivative_str_quotient([0], [2])
+        terms = [t.strip() for t in result.split("+")]
+        self.assertIn("0x^1", terms)
+        self.assertEqual(len(terms), 1)
 
     def test_compute_polynomial_derivative_str_float(self):
-        self.assertEqual(compute_polynomial_derivative_str([1.5, 2.5], [2, 1]), "3.0x^1 + 2.5x^0")
+        result = compute_polynomial_derivative_str_quotient([1.5, 2.5], [2, 1])
+        terms = [t.strip() for t in result.split("+")]
+        self.assertIn("3.0x^1", terms)
+        self.assertIn("2.5x^0", terms)
+        self.assertEqual(len(terms), 2)
 
     def test_compute_polynomial_derivative_str_negative_powers(self):
-        self.assertEqual(compute_polynomial_derivative_str([3], [-2]), "-6x^-3")
+        result = compute_polynomial_derivative_str_quotient([3], [-2])
+        terms = [t.strip() for t in result.split("+")]
+        self.assertIn("-6x^-3", terms)
+        self.assertEqual(len(terms), 1)
 
     def test_compute_polynomial_derivative_str_empty(self):
-        self.assertEqual(compute_polynomial_derivative_str([], []), "0")
+        self.assertEqual(compute_polynomial_derivative_str_quotient([], []), "0")
 
 def test_format_polynomial_integration_multiple_terms():
     result = format_polynomial_integration([2.0, 3.5, 1.0], [2.0, 1.0, 0.0])


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `compute_polynomial_derivative_str` located in `Math/Calculus/Differentiation/quotient_rule.py`.
📊 **Coverage:** The tests in `TestQuotientRule` now correctly target the intended function. They verify basic polynomial differentiation, multiple terms, constant terms, zero coefficients, floating-point coefficients, negative powers, and empty inputs. The assertions were also refactored to verify output string terms independently, increasing test robustness. Additionally, fixed an intermittent module resolution error that prevented test execution.
✨ **Result:** Increased test coverage for `quotient_rule.py` and improved robustness of tests in `TestQuotientRule`.

---
*PR created automatically by Jules for task [13690739867710391936](https://jules.google.com/task/13690739867710391936) started by @Arjundevjha*