### PR TITLE
🧹 Remove unused `List` import from `binomial_theorem.py`

### DIFF
--- a/Math/Discrete_Math/Combinatorics/binomial_theorem.py
+++ b/Math/Discrete_Math/Combinatorics/binomial_theorem.py
@@ -2,8 +2,6 @@
 import sys
 sys.path.append('..')
 from combination import nCr
-sys.path.append('../../..')
-from typing import List
 
 
 def binomial_coefficient(n: int, r: int) -> int:


### PR DESCRIPTION
🎯 **What:** Removed unused `List` import from `typing` and an unnecessary `sys.path.append('../../..')` that preceded it in `Math/Discrete_Math/Combinatorics/binomial_theorem.py`.
💡 **Why:** This improves the code's maintainability by removing unused imports and dead code.
✅ **Verification:** Verified by running the test suite to ensure no tests were broken.
✨ **Result:** Improved codebase health without changing functionality.

---
*PR created automatically by Jules for task [17289436590421790410](https://jules.google.com/task/17289436590421790410) started by @Arjundevjha*