### PR TITLE
🧹 Remove unused List import from trinomial_theorem.py

### DIFF
--- a/Math/Discrete_Math/Combinatorics/trinomial_theorem.py
+++ b/Math/Discrete_Math/Combinatorics/trinomial_theorem.py
@@ -3,7 +3,6 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from combination import nCr
-from typing import List
 
 
 def trinomial_coefficient(n: int, i: int, j: int) -> int:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was removing an unused import of `typing.List` from `Math/Discrete_Math/Combinatorics/trinomial_theorem.py`.

💡 **Why:** This improves maintainability by removing unused and dead code, leading to slightly smaller file sizes, fewer potentially distracting references, and satisfying linters/code-analyzers.

✅ **Verification:** Ran `pytest Tests/test_DiscreteMath.py` to confirm that tests still pass, meaning no functionality was broken.

✨ **Result:** The codebase is cleaner and no longer has this unused import.

---
*PR created automatically by Jules for task [7983853825969814328](https://jules.google.com/task/7983853825969814328) started by @Arjundevjha*