### PR TITLE
🔒 fix unhandled ZeroDivisionError in integrate_polynomial

### DIFF
--- a/Math/Calculus/Integration/NumIntegration.py
+++ b/Math/Calculus/Integration/NumIntegration.py
@@ -18,6 +18,8 @@ def integrate_polynomial(coefficients: List[Union[int, float]], powers: List[Uni
     
     # Apply integration rule: ∫(ax^n)dx = (a/(n+1))×x^(n+1) + C
     for coeff, power in zip(coefficients, powers):
+        if power == -1:
+            raise ValueError("Integration of x^-1 results in ln|x|, which is not supported by this polynomial integration function.")
         new_power = power + 1
         new_coeff = coeff / new_power
         integrated_coeffs.append(new_coeff)

--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -262,20 +262,20 @@ def test_integrate_polynomial_empty():
     assert integrate_polynomial(coeffs, powers) == (expected_coeffs, expected_powers)
 
 def test_integrate_polynomial_power_minus_one():
-    # ∫(x^-1)dx raises ZeroDivisionError in this naive implementation
+    # ∫(x^-1)dx raises ValueError since ln|x| is unsupported
     coeffs = [1]
     powers = [-1]
 
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         integrate_polynomial(coeffs, powers)
 
     assert integrate_polynomial([], []) == ([], [])
 
 def test_integrate_polynomial_power_negative_one():
-    # ∫(x^-1)dx requires ln|x|, the power rule fails with ZeroDivisionError
+    # ∫(x^-1)dx requires ln|x|, the power rule fails with ValueError
     coeffs = [1]
     powers = [-1]
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         integrate_polynomial(coeffs, powers)
 
 def test_integrate_polynomial_mixed_terms():


### PR DESCRIPTION
🎯 **What:** The `integrate_polynomial` function now correctly intercepts the power `-1` and raises a `ValueError` indicating that `ln|x|` is not supported, preventing a raw `ZeroDivisionError`.
⚠️ **Risk:** Without this check, callers handling an integration of `x^-1` encounter an unhandled `ZeroDivisionError` causing crashes, as the formula `(a/(n+1))` fails for `n=-1`.
🛡️ **Solution:** Added a conditional check for `power == -1` which raises a `ValueError` before division by 0 occurs. Corresponding test updates enforce this new safety check.

---
*PR created automatically by Jules for task [2989314105864433587](https://jules.google.com/task/2989314105864433587) started by @Arjundevjha*