### PR TITLE
🧪 Improve test coverage for quotient_rule_derivative and fix fractional power bug

### DIFF
--- a/Math/Calculus/Differentiation/quotient_rule.py
+++ b/Math/Calculus/Differentiation/quotient_rule.py
@@ -15,9 +15,10 @@ def format_polynomial(coefficients: List[Union[int, float]], powers: List[Union[
     """
     terms = []
     for coeff, power in zip(coefficients, powers):
-        term = f"{coeff}x^{int(power)}"
+        power_str = str(int(power)) if float(power).is_integer() else str(power)
+        term = f"{coeff}x^{power_str}"
         terms.append(term)
-    return " + ".join(terms)
+    return " + ".join(terms) if terms else "0"
 
 
 def compute_polynomial_derivative_str(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> str:
@@ -39,7 +40,8 @@ def compute_polynomial_derivative_str(coefficients: List[Union[int, float]], pow
             continue
         new_coeff = coeff * power
         new_power = power - 1
-        derivative_terms.append(f"{new_coeff}x^{int(new_power)}")
+        new_power_str = str(int(new_power)) if float(new_power).is_integer() else str(new_power)
+        derivative_terms.append(f"{new_coeff}x^{new_power_str}")
     
     return " + ".join(derivative_terms) if derivative_terms else "0"
 

--- a/Tests/test_Calculus.py
+++ b/Tests/test_Calculus.py
@@ -145,7 +145,7 @@ def test_format_polynomial_empty():
     coeffs = []
     powers = []
     result = format_polynomial(coeffs, powers)
-    assert result.strip() == ""
+    assert result.strip() == "0"
 
 def test_product_rule_derivative_basic():
     # u(x) = x, v(x) = x
@@ -541,6 +541,23 @@ class TestTrigIntegration:
         """Test integral of cos(x) from 0 to 0 = 0"""
         result = integrate_cos(0, 0)
         assert math.isclose(result, 0.0, abs_tol=1e-9)
+
+class TestQuotientRuleAdditional(unittest.TestCase):
+    def test_quotient_rule_derivative_empty_lists(self):
+        result = quotient_rule_derivative([], [], [1], [1])
+        self.assertEqual(result, "((0) * (1x^1) - (0) * (1x^0)) / (1x^1)^2")
+
+    def test_quotient_rule_derivative_fractional_powers(self):
+        result = quotient_rule_derivative([1], [0.5], [1], [1])
+        self.assertEqual(result, "((0.5x^-0.5) * (1x^1) - (1x^0.5) * (1x^0)) / (1x^1)^2")
+
+    def test_quotient_rule_derivative_zero_polynomial(self):
+        result = quotient_rule_derivative([0], [1], [1], [1])
+        self.assertEqual(result, "((0x^0) * (1x^1) - (0x^1) * (1x^0)) / (1x^1)^2")
+
+    def test_quotient_rule_derivative_happy_path(self):
+        result = quotient_rule_derivative([2], [2], [3], [1])
+        self.assertEqual(result, "((4x^1) * (3x^1) - (2x^2) * (3x^0)) / (3x^1)^2")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Improved test coverage for `quotient_rule_derivative` in `Math/Calculus/Differentiation/quotient_rule.py` and fixed underlying string formatting bugs for fractional powers and empty polynomials.
📊 **Coverage:** Added tests to handle empty polynomial lists, fractional polynomial powers, and a zero polynomial. Also added a happy path test case to cover the default logic.
✨ **Result:** The quotient rule derivative function now handles mathematical edge cases correctly and safely without raising errors, and the tests reflect accurate programmatic behavior. Tests pass consistently and coverage has increased.

---
*PR created automatically by Jules for task [17823156586781623350](https://jules.google.com/task/17823156586781623350) started by @Arjundevjha*