### PR TITLE
🔒 Fix unreachable code due to duplicate return statement

### DIFF
--- a/Math/Algebra/Polynomials/factor_theorem.py
+++ b/Math/Algebra/Polynomials/factor_theorem.py
@@ -1,7 +1,6 @@
 # Factor theorem: check if (x - a) is a factor of a polynomial
 import math
 from typing import List, Union
-import math
 
 
 def evaluate_polynomial(coefficients: List[Union[int, float]], powers: List[Union[int, float]], x: Union[int, float]) -> float:
@@ -36,8 +35,5 @@ def check_factor(coefficients: List[Union[int, float]], powers: List[Union[int, 
     # According to Factor Theorem: (x - a) is a factor if P(a) = 0
     result = evaluate_polynomial(coefficients, powers, x)
     
-    # Use math.isclose to account for floating-point precision issues
-    # Use math.isclose to handle floating-point precision issues
     # Use math.isclose to handle potential floating-point inaccuracies
     return math.isclose(result, 0.0, abs_tol=1e-9)
-    return math.isclose(result, 0, abs_tol=1e-9)


### PR DESCRIPTION
🎯 **What:** Removed duplicate return statement in `check_factor` in `Math/Algebra/Polynomials/factor_theorem.py`. Also removed an extra `import math` at the top.
⚠️ **Risk:** The duplicate return statement leads to unreachable code. While not an active exploit vector, it's poor code hygiene and could lead to developer confusion or unintended consequences if the logic is updated.
🛡️ **Solution:** Removed the duplicate return line and its duplicate comments. Checked the rest of the code for any additional anomalies. Tests passed successfully.

---
*PR created automatically by Jules for task [13936144070610576862](https://jules.google.com/task/13936144070610576862) started by @Arjundevjha*