### PR TITLE
🔒 Fix Unreachable Code in Factor Theorem

### DIFF
--- a/Math/Algebra/Polynomials/factor_theorem.py
+++ b/Math/Algebra/Polynomials/factor_theorem.py
@@ -37,7 +37,4 @@ def check_factor(coefficients: List[Union[int, float]], powers: List[Union[int, 
     result = evaluate_polynomial(coefficients, powers, x)
     
     # Use math.isclose to account for floating-point precision issues
-    # Use math.isclose to handle floating-point precision issues
-    # Use math.isclose to handle potential floating-point inaccuracies
     return math.isclose(result, 0.0, abs_tol=1e-9)
-    return math.isclose(result, 0, abs_tol=1e-9)


### PR DESCRIPTION
🎯 **What:** The unreachable code vulnerability fixed is an unreachable duplicate return statement in `Math/Algebra/Polynomials/factor_theorem.py`.
⚠️ **Risk:** The risk if left unfixed is minor code smell, confusion for future developers reading the code, and potential logic errors if modifications are made around this block in the future without realizing the duplicate exists.
🛡️ **Solution:** The fix removes the duplicate and unreachable return statement, and the duplicate comments, returning the function to clean execution flow.

---
*PR created automatically by Jules for task [17982500796318652615](https://jules.google.com/task/17982500796318652615) started by @Arjundevjha*