### PR TITLE
Fix path imports in test_median.py

### DIFF
--- a/Tests/test_median.py
+++ b/Tests/test_median.py
@@ -1,16 +1,5 @@
-import os
-import sys
-import pytest
 import math
 import unittest
-
-# Fix imports
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Math"))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
 
 from Math.Probability_and_Statistics.Descriptive_Statistics.median import median
 


### PR DESCRIPTION
Removed the anti-pattern sys.path modifications from test_median.py that were used as a workaround to resolve the median function import. This also allows removing unused imports (os, sys, pytest). The tests now rely on correct environment execution (e.g., PYTHONPATH).

---
*PR created automatically by Jules for task [9042496280415524080](https://jules.google.com/task/9042496280415524080) started by @Arjundevjha*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup and imports without changing the existing median test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->