### PR TITLE
refactor(tests): remove sys.path hack from test_mean.py

### DIFF
--- a/Tests/test_mean.py
+++ b/Tests/test_mean.py
@@ -1,15 +1,5 @@
-import os
-import sys
 import unittest
 import math
-
-# Fix imports
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Math"))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
 
 from Math.Probability_and_Statistics.Descriptive_Statistics.mean import mean
 


### PR DESCRIPTION
Removed the hacky `sys.path` modification code from `Tests/test_mean.py` that was used for resolving module imports. Also removed the resulting unused `os` and `sys` module imports. Imports should be resolved natively by running tests from the project root with the correct Python path (e.g., `PYTHONPATH=.:Math pytest`).

---
*PR created automatically by Jules for task [10132655500623727161](https://jules.google.com/task/10132655500623727161) started by @Arjundevjha*