### PR TITLE
Refactor imports in test_circle.py

### DIFF
--- a/Tests/test_circle.py
+++ b/Tests/test_circle.py
@@ -1,15 +1,5 @@
-import os
-import sys
 import math
 import unittest
-
-# Fix imports
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Math"))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
 
 from Math.Geometry.Euclidean_Geometry.Area.circle import area_of_circle
 


### PR DESCRIPTION
Removed the `sys.path.insert` logic from `Tests/test_circle.py` and relied on standard `PYTHONPATH` for resolving module imports, which is a cleaner and non-hacky approach. Tests were verified to pass successfully without it.

---
*PR created automatically by Jules for task [16513202412943357369](https://jules.google.com/task/16513202412943357369) started by @Arjundevjha*