### PR TITLE
Fix: Remove sys.path hack for imports in TrigIntegration

### DIFF
--- a/Math/Calculus/Integration/TrigIntegration.py
+++ b/Math/Calculus/Integration/TrigIntegration.py
@@ -1,12 +1,6 @@
 # Trigonometric integration formulas
-import os
-import sys
-# Add Math to path to fix imports inside Math
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
-from Geometry.Trigonometry.Trig_Functions.sine import sine
-from Geometry.Trigonometry.Trig_Functions.cosine import cosine
+from Math.Geometry.Trigonometry.Trig_Functions.sine import sine
+from Math.Geometry.Trigonometry.Trig_Functions.cosine import cosine
 from typing import Union
 
 


### PR DESCRIPTION
Replaced brittle sys.path manipulation with standard absolute imports in TrigIntegration.py.

---
*PR created automatically by Jules for task [4643334738601485048](https://jules.google.com/task/4643334738601485048) started by @Arjundevjha*