### PR TITLE
Refactor imports in test_triangle.py to remove sys.path hacks

### DIFF
--- a/Tests/test_triangle.py
+++ b/Tests/test_triangle.py
@@ -1,15 +1,5 @@
-import os
-import sys
 import unittest
 import math
-
-# Fix imports
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Math"))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
 
 from Math.Geometry.Euclidean_Geometry.Area.triangle import area_of_triangle
 


### PR DESCRIPTION
Refactor imports in Tests/test_triangle.py

Removed anti-pattern sys.path modifications and unused os and sys imports from Tests/test_triangle.py. The standard testing workflow (e.g., PYTHONPATH=.:Math pytest) will now be relied upon for module resolution, which is a cleaner and more standard approach.

---
*PR created automatically by Jules for task [9667196443043812786](https://jules.google.com/task/9667196443043812786) started by @Arjundevjha*