### PR TITLE
Fix path import hack in simple diffrentiation test

### DIFF
--- a/Tests/test_simple_diffrentiation_function.py
+++ b/Tests/test_simple_diffrentiation_function.py
@@ -1,15 +1,5 @@
-import os
-import sys
 import math
 import unittest
-
-# Fix imports
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Math"))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
 
 from Math.Calculus.Differentiation.simple_diffrentiation_function import differentiate_polynomial
 


### PR DESCRIPTION
Removed the hacky `sys.path` workaround from `Tests/test_simple_diffrentiation_function.py` and deleted unused `os` and `sys` imports. Imports are properly resolved using package configuration or correct execution command parameters (e.g. `PYTHONPATH=.:Math`).

---
*PR created automatically by Jules for task [6817312769246376930](https://jules.google.com/task/6817312769246376930) started by @Arjundevjha*