### PR TITLE
Fix path imports in test_square.py

### DIFF
--- a/Tests/test_square.py
+++ b/Tests/test_square.py
@@ -1,15 +1,5 @@
-import os
-import sys
 import unittest
 import math
-
-# Fix imports
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-math_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Math"))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-if math_dir not in sys.path:
-    sys.path.insert(0, math_dir)
 
 from Math.Geometry.Euclidean_Geometry.Area.square import area_of_square
 


### PR DESCRIPTION
Cleaned up `Tests/test_square.py` by eliminating the `sys.path` anti-pattern for module imports.

---
*PR created automatically by Jules for task [14237170285142306067](https://jules.google.com/task/14237170285142306067) started by @Arjundevjha*