### PR TITLE
🧹 Clean up duplicate comment in factor_theorem.py

### DIFF
--- a/Math/Algebra/Polynomials/factor_theorem.py
+++ b/Math/Algebra/Polynomials/factor_theorem.py
@@ -36,5 +36,4 @@ def check_factor(coefficients: List[Union[int, float]], powers: List[Union[int, 
     result = evaluate_polynomial(coefficients, powers, x)
     
     # Use math.isclose to account for floating-point precision issues
-    # Use math.isclose to handle potential floating-point inaccuracies
     return math.isclose(result, 0.0, abs_tol=1e-9)


### PR DESCRIPTION
🎯 **What:** Removed duplicate `math.isclose` comments in `factor_theorem.py`
💡 **Why:** The file contained redundant documentation comments above the return statement. (The unreachable return statement mentioned in the original report was already removed in a previous merge).
✅ **Verification:** Verified by checking tests with `pytest Tests/test_factor_theorem.py` which all passed, and confirming no linting errors with `ruff`.
✨ **Result:** A cleaner, more readable `check_factor` function without duplicated comments.

---
*PR created automatically by Jules for task [4390901946078375865](https://jules.google.com/task/4390901946078375865) started by @Arjundevjha*