### PR TITLE
🔒 Fix Missing Input Validation for Polynomial Power (DoS prevention)

### DIFF
--- a/Math/Algebra/Polynomials/polynomial.py
+++ b/Math/Algebra/Polynomials/polynomial.py
@@ -15,6 +15,11 @@ def evaluate_polynomial(coefficients: List[Union[int, float]], powers: List[Unio
     float: The value of the polynomial at x.
     """
     # Calculate polynomial value: P(x) = Σ(coefficient × x^power)
+    MAX_POWER = 1000
+    for power in powers:
+        if power > MAX_POWER:
+            raise ValueError(f"Power {power} exceeds maximum allowed value of {MAX_POWER}")
+
     result = sum(coeff * (x ** power) for coeff, power in zip(coefficients, powers))
     return result
 

--- a/Tests/test_Algebra.py
+++ b/Tests/test_Algebra.py
@@ -248,6 +248,11 @@ class TestEvaluatePolynomial:
         # x^10 at x=2 -> 1024
         assert evaluate_polynomial([1], [10], 2) == 1024
 
+    def test_evaluate_polynomial_excessive_power(self):
+        """Test with power exceeding maximum allowed value raises ValueError"""
+        with pytest.raises(ValueError, match="Power 1001 exceeds maximum allowed value of 1000"):
+            evaluate_polynomial([1], [1001], 2)
+
     def test_evaluate_polynomial_precision(self):
         """Test with small floats where precision might be an issue"""
         # 0.1 * x^2 + 0.2 * x at x=0.3


### PR DESCRIPTION
🎯 **What:** Missing input validation in `evaluate_polynomial` for polynomial powers allowed computing arbitrarily large exponents without limit.
⚠️ **Risk:** An attacker could cause extreme CPU and memory resource consumption (Denial of Service) by passing excessively large integer powers (e.g., `x**100000000`), which causes Python to generate massive integers.
🛡️ **Solution:** Implemented a hard limit (e.g., 1000) on polynomial powers. A `ValueError` is immediately raised if a power exceeds the `MAX_POWER` limit before any evaluation begins, mitigating the DoS risk. Added testing to ensure the exception is correctly thrown.

---
*PR created automatically by Jules for task [11749633930766156277](https://jules.google.com/task/11749633930766156277) started by @Arjundevjha*