### PR TITLE
🧹 Refactor: Extract polynomial utilities to shared module

### DIFF
--- a/Math/Calculus/Differentiation/chain_rule.py
+++ b/Math/Calculus/Differentiation/chain_rule.py
@@ -1,50 +1,14 @@
 # Chain rule for differentiation of composite functions
-from typing import List, Union, Tuple
+from typing import List, Union
+
+from .utils import format_polynomial, compute_polynomial_derivative
 
 
-def format_polynomial(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> str:
-    """
-    Format a polynomial as a string.
-
-    Parameters:
-    coefficients (List[Union[int, float]]): List of coefficients.
-    powers (List[Union[int, float]]): List of powers.
-
-    Returns:
-    str: String representation of the polynomial.
-    """
-    terms = []
-    for coeff, power in zip(coefficients, powers):
-        term = f"{coeff}x^{int(power)}"
-        terms.append(term)
-    return " + ".join(terms)
-
-
-def compute_polynomial_derivative(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> Tuple[List[float], List[float]]:
-    """
-    Compute the derivative of a polynomial.
-
-    Parameters:
-    coefficients (List[Union[int, float]]): List of coefficients.
-    powers (List[Union[int, float]]): List of powers.
-
-    Returns:
-    Tuple[List[float], List[float]]: Lists of derivative coefficients and powers.
-    """
-    derivative_coeffs = []
-    derivative_powers = []
-    
-    # Apply power rule: d/dx(ax^n) = n×a×x^(n-1)
-    for coeff, power in zip(coefficients, powers):
-        if power == 0:
-            continue
-        derivative_coeffs.append(coeff * power)
-        derivative_powers.append(power - 1)
-    
-    return derivative_coeffs, derivative_powers
-
-
-def chain_rule_derivative(inner_coeffs: List[Union[int, float]], inner_powers: List[Union[int, float]], exponent: int) -> str:
+def chain_rule_derivative(
+    inner_coeffs: List[Union[int, float]],
+    inner_powers: List[Union[int, float]],
+    exponent: int,
+) -> str:
     """
     Apply the chain rule to find the derivative of [g(x)]^n.
 
@@ -58,19 +22,21 @@ def chain_rule_derivative(inner_coeffs: List[Union[int, float]], inner_powers: L
     """
     if exponent < 0:
         raise ValueError("Exponent must be non-negative.")
-    
+
     # Format inner polynomial g(x)
     g_x = format_polynomial(inner_coeffs, inner_powers)
-    
+
     # Compute derivative of inner function g'(x)
-    g_prime_coeffs, g_prime_powers = compute_polynomial_derivative(inner_coeffs, inner_powers)
-    
+    g_prime_coeffs, g_prime_powers = compute_polynomial_derivative(
+        inner_coeffs, inner_powers
+    )
+
     derivative_terms = []
     for coeff, power in zip(g_prime_coeffs, g_prime_powers):
         derivative_terms.append(f"{coeff}x^{int(power)}")
     g_prime = " + ".join(derivative_terms)
-    
+
     # Apply chain rule: d/dx[g(x)]^n = n×[g(x)]^(n-1) × g'(x)
     result = f"{exponent}({g_x})^{exponent - 1} * ({g_prime})"
-    
+
     return result

--- a/Math/Calculus/Differentiation/product_rule.py
+++ b/Math/Calculus/Differentiation/product_rule.py
@@ -1,51 +1,15 @@
 # Product rule for differentiation
 from typing import List, Union
 
-
-def format_polynomial(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> str:
-    """
-    Format a polynomial as a string.
-
-    Parameters:
-    coefficients (List[Union[int, float]]): List of coefficients.
-    powers (List[Union[int, float]]): List of powers.
-
-    Returns:
-    str: String representation of the polynomial.
-    """
-    terms = []
-    for coeff, power in zip(coefficients, powers):
-        term = f"{coeff}x^{int(power)}"
-        terms.append(term)
-    return " + ".join(terms)
+from .utils import format_polynomial, compute_polynomial_derivative_str
 
 
-def compute_polynomial_derivative_str(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> str:
-    """
-    Compute the derivative of a polynomial and return as string.
-
-    Parameters:
-    coefficients (List[Union[int, float]]): List of coefficients.
-    powers (List[Union[int, float]]): List of powers.
-
-    Returns:
-    str: String representation of the derivative.
-    """
-    derivative_terms = []
-    
-    # Apply power rule: d/dx(ax^n) = n×a×x^(n-1)
-    for coeff, power in zip(coefficients, powers):
-        if power == 0:
-            continue
-        new_coeff = coeff * power
-        new_power = power - 1
-        derivative_terms.append(f"{new_coeff}x^{int(new_power)}")
-    
-    return " + ".join(derivative_terms) if derivative_terms else "0"
-
-
-def product_rule_derivative(u_coeffs: List[Union[int, float]], u_powers: List[Union[int, float]], 
-                            v_coeffs: List[Union[int, float]], v_powers: List[Union[int, float]]) -> str:
+def product_rule_derivative(
+    u_coeffs: List[Union[int, float]],
+    u_powers: List[Union[int, float]],
+    v_coeffs: List[Union[int, float]],
+    v_powers: List[Union[int, float]],
+) -> str:
     """
     Apply the product rule to find the derivative of u(x) * v(x).
 
@@ -61,14 +25,14 @@ def product_rule_derivative(u_coeffs: List[Union[int, float]], u_powers: List[Un
     # Format polynomials
     poly1 = format_polynomial(u_coeffs, u_powers)
     poly2 = format_polynomial(v_coeffs, v_powers)
-    
+
     # Compute derivatives
     u_prime = compute_polynomial_derivative_str(u_coeffs, u_powers)
     v_prime = compute_polynomial_derivative_str(v_coeffs, v_powers)
-    
+
     # Apply product rule: (u×v)' = u'×v + u×v'
     if not u_coeffs and not v_coeffs:
         return "0"
     result = f"({u_prime}) * ({poly2}) + ({poly1}) * ({v_prime})"
-    
+
     return result

--- a/Math/Calculus/Differentiation/quotient_rule.py
+++ b/Math/Calculus/Differentiation/quotient_rule.py
@@ -1,51 +1,15 @@
 # Quotient rule for differentiation
 from typing import List, Union
 
-
-def format_polynomial(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> str:
-    """
-    Format a polynomial as a string.
-
-    Parameters:
-    coefficients (List[Union[int, float]]): List of coefficients.
-    powers (List[Union[int, float]]): List of powers.
-
-    Returns:
-    str: String representation of the polynomial.
-    """
-    terms = []
-    for coeff, power in zip(coefficients, powers):
-        term = f"{coeff}x^{int(power)}"
-        terms.append(term)
-    return " + ".join(terms)
+from .utils import format_polynomial, compute_polynomial_derivative_str
 
 
-def compute_polynomial_derivative_str(coefficients: List[Union[int, float]], powers: List[Union[int, float]]) -> str:
-    """
-    Compute the derivative of a polynomial and return as string.
-
-    Parameters:
-    coefficients (List[Union[int, float]]): List of coefficients.
-    powers (List[Union[int, float]]): List of powers.
-
-    Returns:
-    str: String representation of the derivative.
-    """
-    derivative_terms = []
-    
-    # Apply power rule: d/dx(ax^n) = n×a×x^(n-1)
-    for coeff, power in zip(coefficients, powers):
-        if power == 0:
-            continue
-        new_coeff = coeff * power
-        new_power = power - 1
-        derivative_terms.append(f"{new_coeff}x^{int(new_power)}")
-    
-    return " + ".join(derivative_terms) if derivative_terms else "0"
-
-
-def quotient_rule_derivative(u_coeffs: List[Union[int, float]], u_powers: List[Union[int, float]], 
-                             v_coeffs: List[Union[int, float]], v_powers: List[Union[int, float]]) -> str:
+def quotient_rule_derivative(
+    u_coeffs: List[Union[int, float]],
+    u_powers: List[Union[int, float]],
+    v_coeffs: List[Union[int, float]],
+    v_powers: List[Union[int, float]],
+) -> str:
     """
     Apply the quotient rule to find the derivative of u(x) / v(x).
 
@@ -61,14 +25,14 @@ def quotient_rule_derivative(u_coeffs: List[Union[int, float]], u_powers: List[U
     # Format polynomials
     poly1 = format_polynomial(u_coeffs, u_powers)
     poly2 = format_polynomial(v_coeffs, v_powers)
-    
+
     # Compute derivatives
     u_prime = compute_polynomial_derivative_str(u_coeffs, u_powers)
     v_prime = compute_polynomial_derivative_str(v_coeffs, v_powers)
-    
+
     # Apply quotient rule: (u/v)' = (u'×v - u×v') / v²
     numerator = f"({u_prime}) * ({poly2}) - ({poly1}) * ({v_prime})"
     denominator = f"({poly2})^2"
     result = f"({numerator}) / {denominator}"
-    
+
     return result

--- a/Math/Calculus/Differentiation/second_derivatives.py
+++ b/Math/Calculus/Differentiation/second_derivatives.py
@@ -2,7 +2,9 @@
 from typing import List, Union
 
 
-def second_derivative(coeffs: List[Union[int, float]], powers: List[Union[int, float]]) -> List[tuple]:
+def second_derivative(
+    coeffs: List[Union[int, float]], powers: List[Union[int, float]]
+) -> List[tuple]:
     """
     Calculate the second derivative of a polynomial.
 
@@ -16,16 +18,16 @@ def second_derivative(coeffs: List[Union[int, float]], powers: List[Union[int, f
     # First derivative: d/dx(ax^n) = n×a×x^(n-1)
     first_deriv_coeffs = []
     first_deriv_powers = []
-    
+
     for coeff, power in zip(coeffs, powers):
         if power > 0:
             first_deriv_coeffs.append(coeff * power)
             first_deriv_powers.append(power - 1)
-    
+
     # Second derivative: apply derivative again
     second_deriv = []
     for coeff, power in zip(first_deriv_coeffs, first_deriv_powers):
         if power > 0:
             second_deriv.append((coeff * power, power - 1))
-    
+
     return second_deriv

--- a/Math/Calculus/Differentiation/simple_diffrentiation_function.py
+++ b/Math/Calculus/Differentiation/simple_diffrentiation_function.py
@@ -2,7 +2,9 @@
 from typing import List, Union, Tuple
 
 
-def differentiate_polynomial(coeffs: List[Union[int, float]], powers: List[Union[int, float]]) -> List[Tuple[float, float]]:
+def differentiate_polynomial(
+    coeffs: List[Union[int, float]], powers: List[Union[int, float]]
+) -> List[Tuple[float, float]]:
     """
     Differentiate a polynomial using the power rule.
 
@@ -14,12 +16,12 @@ def differentiate_polynomial(coeffs: List[Union[int, float]], powers: List[Union
     List[Tuple[float, float]]: List of tuples (coefficient, power) for the derivative.
     """
     derivative = []
-    
+
     # Apply power rule: d/dx(ax^n) = n×a×x^(n-1)
     for coeff, power in zip(coeffs, powers):
         if power > 0:
             new_coeff = coeff * power
             new_power = power - 1
             derivative.append((new_coeff, new_power))
-    
+
     return derivative

--- a/Math/Calculus/Differentiation/utils.py
+++ b/Math/Calculus/Differentiation/utils.py
@@ -1,0 +1,73 @@
+from typing import List, Union, Tuple
+
+
+def format_polynomial(
+    coefficients: List[Union[int, float]], powers: List[Union[int, float]]
+) -> str:
+    """
+    Format a polynomial as a string.
+
+    Parameters:
+    coefficients (List[Union[int, float]]): List of coefficients.
+    powers (List[Union[int, float]]): List of powers.
+
+    Returns:
+    str: String representation of the polynomial.
+    """
+    terms = []
+    for coeff, power in zip(coefficients, powers):
+        term = f"{coeff}x^{int(power)}"
+        terms.append(term)
+    return " + ".join(terms)
+
+
+def compute_polynomial_derivative_str(
+    coefficients: List[Union[int, float]], powers: List[Union[int, float]]
+) -> str:
+    """
+    Compute the derivative of a polynomial and return as string.
+
+    Parameters:
+    coefficients (List[Union[int, float]]): List of coefficients.
+    powers (List[Union[int, float]]): List of powers.
+
+    Returns:
+    str: String representation of the derivative.
+    """
+    derivative_terms = []
+
+    # Apply power rule: d/dx(ax^n) = n×a×x^(n-1)
+    for coeff, power in zip(coefficients, powers):
+        if power == 0:
+            continue
+        new_coeff = coeff * power
+        new_power = power - 1
+        derivative_terms.append(f"{new_coeff}x^{int(new_power)}")
+
+    return " + ".join(derivative_terms) if derivative_terms else "0"
+
+
+def compute_polynomial_derivative(
+    coefficients: List[Union[int, float]], powers: List[Union[int, float]]
+) -> Tuple[List[float], List[float]]:
+    """
+    Compute the derivative of a polynomial.
+
+    Parameters:
+    coefficients (List[Union[int, float]]): List of coefficients.
+    powers (List[Union[int, float]]): List of powers.
+
+    Returns:
+    Tuple[List[float], List[float]]: Lists of derivative coefficients and powers.
+    """
+    derivative_coeffs = []
+    derivative_powers = []
+
+    # Apply power rule: d/dx(ax^n) = n×a×x^(n-1)
+    for coeff, power in zip(coefficients, powers):
+        if power == 0:
+            continue
+        derivative_coeffs.append(coeff * power)
+        derivative_powers.append(power - 1)
+
+    return derivative_coeffs, derivative_powers


### PR DESCRIPTION
🎯 **What:** Extracted duplicated utility functions (`format_polynomial`, `compute_polynomial_derivative_str`, and `compute_polynomial_derivative`) from `product_rule.py`, `quotient_rule.py`, and `chain_rule.py` into a new shared `utils.py` file within `Math/Calculus/Differentiation/`.
💡 **Why:** These utility functions were identical across multiple files in the same directory, leading to code duplication. Moving them to a shared utility file improves code maintainability, reusability, and readability, avoiding the need to update logic in multiple places in the future.
✅ **Verification:** Verified by running the entire test suite via `pytest` (all tests passed), performing static analysis and formatting checks using `ruff` (no errors), and explicitly requesting a code review (received an approval rating).
✨ **Result:** Improved code health by removing duplicate code and centralizing polynomial differentiation formatting logic into a single, importable location.

---
*PR created automatically by Jules for task [4073830917982165342](https://jules.google.com/task/4073830917982165342) started by @Arjundevjha*