### PR TITLE
🔒 Fix missing input validation on precision parameter in nth_root

### DIFF
--- a/Math/Numerical_Methods/Functions/nth_root/nth_root.py
+++ b/Math/Numerical_Methods/Functions/nth_root/nth_root.py
@@ -21,6 +21,8 @@ def nth_root(
     Union[float, Decimal]: The n-th root of x.
     """
     if precision is not None:
+        if precision <= 0 or precision > 10000:
+            raise ValueError("precision must be between 1 and 10000")
         getcontext().prec = precision
 
     is_decimal = (

--- a/Tests/test_NumericalMethods.py
+++ b/Tests/test_NumericalMethods.py
@@ -136,6 +136,20 @@ def test_nth_root_invalid_degree():
         nth_root(8, 0)
 
 
+
+def test_nth_root_decimal_precision_bounds():
+    # Test that precision < 1 raises ValueError
+    with pytest.raises(ValueError, match="precision must be between 1 and 10000"):
+        nth_root(2, 3, precision=0)
+
+    with pytest.raises(ValueError, match="precision must be between 1 and 10000"):
+        nth_root(2, 3, precision=-5)
+
+    # Test that precision > 10000 raises ValueError
+    with pytest.raises(ValueError, match="precision must be between 1 and 10000"):
+        nth_root(2, 3, precision=10001)
+
+
 def test_nth_root_decimal_precision():
     x = Decimal("2")
     n = Decimal("3")


### PR DESCRIPTION
🎯 **What:** The `precision` parameter in `Math/Numerical_Methods/Functions/nth_root/nth_root.py` lacked upper/lower bound validation before being passed to `getcontext().prec = precision`.
⚠️ **Risk:** An attacker or malicious user could supply extremely large values (e.g., billions) or negative values, leading to memory exhaustion (MemoryError) or excessive CPU consumption (Denial of Service) during Decimal computation.
🛡️ **Solution:** Implemented bounds validation ensuring `0 < precision <= 10000`, raising a `ValueError` for inputs outside this safe range, and added corresponding unit tests to verify the fix.

---
*PR created automatically by Jules for task [7047500937323449220](https://jules.google.com/task/7047500937323449220) started by @Arjundevjha*