### PR TITLE
🧪 Add tests for volume_of_prism

### DIFF
--- a/Tests/test_volume_of_prism.py
+++ b/Tests/test_volume_of_prism.py
@@ -1,0 +1,30 @@
+import unittest
+import math
+from Math.Geometry.Euclidean_Geometry.Volume.prism import volume_of_prism
+
+class TestVolumeOfPrism(unittest.TestCase):
+    def test_positive_integers(self):
+        self.assertEqual(volume_of_prism(10, 5), 50.0)
+
+    def test_positive_floats(self):
+        self.assertTrue(math.isclose(volume_of_prism(2.5, 4.2), 10.5, rel_tol=1e-9))
+
+    def test_mixed_types(self):
+        self.assertTrue(math.isclose(volume_of_prism(2, 4.5), 9.0, rel_tol=1e-9))
+        self.assertTrue(math.isclose(volume_of_prism(2.5, 4), 10.0, rel_tol=1e-9))
+
+    def test_zero_dimensions(self):
+        self.assertEqual(volume_of_prism(0, 5), 0)
+        self.assertEqual(volume_of_prism(5, 0), 0)
+        self.assertEqual(volume_of_prism(0, 0), 0)
+
+    def test_negative_dimensions_raise_value_error(self):
+        with self.assertRaises(ValueError):
+            volume_of_prism(-1, 5)
+        with self.assertRaises(ValueError):
+            volume_of_prism(5, -1)
+        with self.assertRaises(ValueError):
+            volume_of_prism(-1, -1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added a missing test suite for `volume_of_prism` in `Math/Geometry/Euclidean_Geometry/Volume/prism.py`.

📊 **Coverage:** Covered tests for positive integers, positive floats, mixed types, and zero dimensions.

✨ **Result:** Increased test coverage and ensured standard cases are correctly evaluated and assertions using math.isclose to handle float precision issues.

---
*PR created automatically by Jules for task [15090679847587111721](https://jules.google.com/task/15090679847587111721) started by @Arjundevjha*