### PR TITLE
🧪 test: add tests and fix coefficient bug in William Shanks Pi algorithm

### DIFF
--- a/Math/Numerical_Methods/Constants/Pi_Algorithms/William_Shanks.py
+++ b/Math/Numerical_Methods/Constants/Pi_Algorithms/William_Shanks.py
@@ -37,7 +37,7 @@ def calculate_pi_shanks(precision: int = 50) -> Decimal:
     
     Formula: π/4 = 1587×arctan(1/2852) + 295×arctan(1/4193) + 593×arctan(1/4246) 
                    + 359×arctan(1/39307) + 481×arctan(1/55603) + 625×arctan(1/211050) 
-                   - 728×arctan(1/390112)
+                   - 708×arctan(1/390112)
 
     Parameters:
     precision (int): The number of decimal places for the result (default: 50).
@@ -55,6 +55,6 @@ def calculate_pi_shanks(precision: int = 50) -> Decimal:
                  359 * calculate_arctan_series_shanks(39307, precision) +
                  481 * calculate_arctan_series_shanks(55603, precision) +
                  625 * calculate_arctan_series_shanks(211050, precision) -
-                 728 * calculate_arctan_series_shanks(390112, precision))
+                 708 * calculate_arctan_series_shanks(390112, precision))
     
     return pi_over_4 * 4

--- a/Tests/test_William_Shanks.py
+++ b/Tests/test_William_Shanks.py
@@ -1,0 +1,60 @@
+import math
+from decimal import Decimal
+from Math.Numerical_Methods.Constants.Pi_Algorithms.William_Shanks import (
+    calculate_pi_shanks,
+    calculate_arctan_series_shanks,
+)
+
+
+class TestWilliamShanks:
+    def test_calculate_pi_shanks_default_precision(self):
+        """Test calculating Pi with default precision (50 places)."""
+        pi_shanks = calculate_pi_shanks()
+        assert isinstance(pi_shanks, Decimal)
+
+        # William Shanks' calculation converges up to the specified precision,
+        # but due to truncation in Taylor series, the very last digits might be slightly off.
+        # We test the first 45 decimal places to ensure it's sufficiently accurate.
+        expected_pi = "3.141592653589793238462643383279502884197169399"
+
+        pi_str = str(pi_shanks)
+        assert pi_str.startswith(expected_pi)
+
+    def test_calculate_pi_shanks_custom_precision(self):
+        """Test calculating Pi with a custom precision."""
+        # 10 decimal places -> the algorithm gives ~3.1415927...
+        # So it's accurate to about 6 decimal places with precision=10
+        # due to the Taylor series term truncation condition.
+        pi_shanks_10 = calculate_pi_shanks(10)
+        assert isinstance(pi_shanks_10, Decimal)
+
+        expected_pi_10 = "3.141592"
+        pi_str_10 = str(pi_shanks_10)
+
+        assert pi_str_10.startswith(expected_pi_10)
+
+    def test_calculate_pi_shanks_high_precision(self):
+        """Test calculating Pi with high precision."""
+        pi_shanks_100 = calculate_pi_shanks(100)
+        assert isinstance(pi_shanks_100, Decimal)
+
+        # Checking the first 95 decimal places
+        expected_pi_100 = (
+            "3.14159265358979323846264338327950288419716939937510"
+            "5820974944592307816406286208998628034825342"
+        )
+        pi_str_100 = str(pi_shanks_100)
+
+        assert pi_str_100.startswith(expected_pi_100)
+
+    def test_calculate_arctan_series_shanks(self):
+        """Test the helper arctan calculation function."""
+        # arctan(0) should return Decimal(0)
+        assert calculate_arctan_series_shanks(0, 10) == Decimal(0)
+
+        # Test a real value, e.g., arctan(1/2)
+        arctan_2 = calculate_arctan_series_shanks(2, 10)
+        assert isinstance(arctan_2, Decimal)
+
+        # arctan(1/2) is approx 0.463647609
+        assert math.isclose(float(arctan_2), math.atan(0.5), rel_tol=1e-9)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Added tests for `calculate_pi_shanks` and its arctan helper. Also fixed a bug in the underlying mathematical formula implementation.
📊 **Coverage:** What scenarios are now tested: Covered default precision (50 digits), low precision (10), high precision (100) using substring matching against the expected Pi digits in Decimal format.
✨ **Result:** The improvement in test coverage: The algorithm is now thoroughly tested and accurately produces the digits of Pi.

---
*PR created automatically by Jules for task [2468738246389789635](https://jules.google.com/task/2468738246389789635) started by @Arjundevjha*